### PR TITLE
test: cover 8-char password rule and harden setup assertion

### DIFF
--- a/tests/test_change_password.py
+++ b/tests/test_change_password.py
@@ -1,0 +1,26 @@
+"""Covers the 8-character minimum password rule (added upstream). The change-
+password dialog enforces the same rule as first-run setup, and a rejection
+leaves the password unchanged, so it is safe to run against the shared session."""
+from playwright.sync_api import expect
+
+from conftest import PASSWORD
+
+
+def _open_change_password(page):
+    page.goto("/")
+    expect(page.get_by_text("Server databases")).to_be_visible()
+    page.get_by_role("button", name="Preferences").click()
+    page.get_by_role("button", name="Change password").click()
+
+
+def test_rejects_password_shorter_than_8(authed_page):
+    _open_change_password(authed_page)
+
+    authed_page.get_by_label("Current password").fill(PASSWORD)
+    authed_page.get_by_label("New password", exact=True).fill("short7!")  # 7 chars
+    authed_page.get_by_label("Confirm new password").fill("short7!")
+    authed_page.get_by_role("button", name="Save").click()
+
+    expect(authed_page.locator("#snackbar")).to_contain_text(
+        "Password must be at least 8 characters"
+    )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,11 +1,14 @@
 """The first-run setup flow is performed by the `auth_state` fixture (it can
 only run once per docroot). Here we confirm it produced a working session that
 boots straight to the database picker."""
+from playwright.sync_api import expect
 
 
 def test_authenticated_session_reaches_database_picker(authed_page):
     authed_page.goto("/")
-    assert authed_page.get_by_text("Server databases").is_visible()
-    assert authed_page.get_by_role(
-        "heading", name="Sample Database"
-    ).is_visible()
+    # The app boots asynchronously (fetch session, then render), so these must
+    # auto-wait rather than assert on an instantaneous is_visible().
+    expect(authed_page.get_by_text("Server databases")).to_be_visible()
+    expect(
+        authed_page.get_by_role("heading", name="Sample Database")
+    ).to_be_visible()


### PR DESCRIPTION
> Drafted by Claude (Opus 4.8) at Andy's direction.

Upstream added an 8-character minimum to setup/change_password without test coverage; add a change-password rejection test for it. Also switch the setup test from a non-waiting is_visible() to auto-waiting expect(), which an upstream boot-timing shift had tipped into a consistent failure.